### PR TITLE
Add GitHub Pages deployment for CDN access

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,48 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build
+        run: yarn build
+
+      - name: Prepare pages output
+        run: |
+          mkdir -p _site
+          cp -r modules/tinymce/js/tinymce/* _site/
+
+      - uses: actions/configure-pages@v5
+
+      - uses: actions/upload-pages-artifact@v3
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- Adds a workflow that builds TinyMCE and deploys to GitHub Pages on every push to `main`
- Enables using this fork in CodePen and external projects via URL

## Usage

After merge, TinyMCE will be available at:
```
https://lostkeys.github.io/tinymce-ai/tinymce.min.js
```

**CodePen example:**
```html
<script src="https://lostkeys.github.io/tinymce-ai/tinymce.min.js"></script>
<textarea id="editor"></textarea>
<script>
  tinymce.init({ selector: '#editor', plugins: 'wordcount' });
</script>
```

All plugins, skins, themes, icons, and models are included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)