### PR TITLE
Fix fontsizeinput to respect font_size_input_default_unit

### DIFF
--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontSizeBespoke.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/complex/FontSizeBespoke.ts
@@ -57,14 +57,30 @@ const round = (number: number, precision: number) => {
   return Math.round(number * factor) / factor;
 };
 
-const toPt = (fontSize: string, precision?: number): string => {
-  if (/[0-9.]+px$/.test(fontSize)) {
-    // Round to the nearest 0.5
-    return round(parseInt(fontSize, 10) * 72 / 96, precision || 0) + 'pt';
-  } else {
-    return Obj.get(keywordFontSizes, fontSize).getOr(fontSize);
-  }
+// Conversion factors from px to other units (assuming 96 DPI)
+const pxConversionFactors: Record<string, number> = {
+  px: 1,
+  pt: 72 / 96,
+  pc: 6 / 96,
+  in: 1 / 96,
+  cm: 2.54 / 96,
+  mm: 25.4 / 96
 };
+
+const convertFromPx = (fontSize: string, targetUnit: string, precision?: number): Optional<string> => {
+  if (/[0-9.]+px$/.test(fontSize)) {
+    const factor = pxConversionFactors[targetUnit];
+    if (factor !== undefined) {
+      return Optional.some(round(parseFloat(fontSize) * factor, precision ?? 0) + targetUnit);
+    }
+  }
+  return Optional.none();
+};
+
+const toPt = (fontSize: string, precision?: number): string =>
+  convertFromPx(fontSize, 'pt', precision).getOrThunk(() =>
+    Obj.get(keywordFontSizes, fontSize).getOr(fontSize)
+  );
 
 const toLegacy = (fontSize: string): string => Obj.get(legacyFontSizes, fontSize).getOr('');
 
@@ -150,10 +166,38 @@ const getConfigFromUnit = (unit: string): Config => {
 const defaultValue = 16;
 const isValidValue = (value: number): boolean => value >= 0;
 
+const convertToUnit = (fontSize: string, targetUnit: string): string => {
+  // If already in the target unit, return as-is
+  if (fontSize.endsWith(targetUnit)) {
+    return fontSize;
+  }
+  // Try keyword conversion first
+  const fromKeyword = Obj.get(keywordFontSizes, fontSize);
+  if (fromKeyword.isSome()) {
+    const ptValue = fromKeyword.getOr(fontSize);
+    if (targetUnit === 'pt') {
+      return ptValue;
+    }
+    // Convert keyword's pt value to px first, then to target
+    const pxValue = parseFloat(ptValue) * 96 / 72;
+    return convertFromPx(pxValue + 'px', targetUnit, 1).getOr(fontSize);
+  }
+  // Convert from px to target unit
+  return convertFromPx(fontSize, targetUnit, 1).getOr(fontSize);
+};
+
 const getNumberInputSpec = (editor: Editor): NumberInputSpec => {
-  const getCurrentValue = () => editor.queryCommandValue('FontSize');
+  const getRawValue = () => editor.queryCommandValue('FontSize');
+  const getDisplayValue = (): string => {
+    const raw = getRawValue();
+    if (!raw) {
+      return raw;
+    }
+    const defaultUnit = Options.getFontSizeInputDefaultUnit(editor);
+    return convertToUnit(raw, defaultUnit);
+  };
   const updateInputValue = (comp: AlloyComponent) => AlloyTriggers.emitWith(comp, updateMenuText, {
-    text: getCurrentValue()
+    text: getDisplayValue()
   });
 
   return {
@@ -162,7 +206,7 @@ const getNumberInputSpec = (editor: Editor): NumberInputSpec => {
     getNewValue: (text, updateFunction) => {
       Dimension.parse(text, [ 'unsupportedLength', 'empty' ]);
 
-      const currentValue = getCurrentValue();
+      const currentValue = getDisplayValue();
       const parsedText = Dimension.parse(text, [ 'unsupportedLength', 'empty' ]).or(
         Dimension.parse(currentValue, [ 'unsupportedLength', 'empty' ])
       );

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/FontSizeInputUnitConversionTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/toolbar/FontSizeInputUnitConversionTest.ts
@@ -1,0 +1,153 @@
+import { FocusTools, Keys, UiControls, UiFinder, Waiter } from '@ephox/agar';
+import { context, describe, it } from '@ephox/bedrock-client';
+import { SugarShadowDom, Value } from '@ephox/sugar';
+import { TinyAssertions, TinyDom, TinyHooks, TinySelections, TinyUiActions } from '@ephox/wrap-mcagar';
+import { assert } from 'chai';
+
+import type Editor from 'tinymce/core/api/Editor';
+
+describe('browser.tinymce.themes.silver.editor.toolbar.FontSizeInputUnitConversionTest', () => {
+
+  const getInputValue = (editor: Editor): string => {
+    const input = UiFinder.findIn<HTMLInputElement>(TinyUiActions.getUiRoot(editor), '.tox-number-input input').getOrDie();
+    return Value.get(input);
+  };
+
+  const pWaitForInputValue = (editor: Editor, expected: string): Promise<void> =>
+    Waiter.pTryUntil(`Input should show "${expected}"`, () => {
+      assert.equal(getInputValue(editor), expected);
+    });
+
+  context('Default unit (pt)', () => {
+    const hook = TinyHooks.bddSetupLight<Editor>({
+      base_url: '/project/tinymce/js/tinymce',
+      toolbar: [ 'fontsizeinput' ]
+    }, []);
+
+    it('TINY-UNIT-1: should display font size converted to pt when content is in px', async () => {
+      const editor = hook.editor();
+      editor.setContent('<p style="font-size: 16px;">abc</p>');
+      TinySelections.setCursor(editor, [ 0, 0 ], 1);
+      await pWaitForInputValue(editor, '12pt');
+    });
+
+    it('TINY-UNIT-2: should display pt value directly when content is already in pt', async () => {
+      const editor = hook.editor();
+      editor.setContent('<p style="font-size: 14pt;">abc</p>');
+      TinySelections.setCursor(editor, [ 0, 0 ], 1);
+      // The browser computes pt values to px, so queryCommandValue returns px
+      // 14pt = 18.67px, which converts back to ~14pt
+      await pWaitForInputValue(editor, '14pt');
+    });
+
+    it('TINY-UNIT-3: increment/decrement should work in pt unit', async () => {
+      const editor = hook.editor();
+      editor.setContent('<p style="font-size: 16px;">abc</p>');
+      TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 3);
+      await pWaitForInputValue(editor, '12pt');
+
+      TinyUiActions.clickOnToolbar(editor, '.tox-number-input .plus');
+      await pWaitForInputValue(editor, '13pt');
+
+      TinyUiActions.clickOnToolbar(editor, '.tox-number-input .minus');
+      await pWaitForInputValue(editor, '12pt');
+    });
+  });
+
+  context('Configured unit: px', () => {
+    const hook = TinyHooks.bddSetupLight<Editor>({
+      base_url: '/project/tinymce/js/tinymce',
+      toolbar: [ 'fontsizeinput' ],
+      font_size_input_default_unit: 'px'
+    }, []);
+
+    it('TINY-UNIT-4: should display font size in px when unit is configured as px', async () => {
+      const editor = hook.editor();
+      editor.setContent('<p style="font-size: 16px;">abc</p>');
+      TinySelections.setCursor(editor, [ 0, 0 ], 1);
+      await pWaitForInputValue(editor, '16px');
+    });
+
+    it('TINY-UNIT-5: increment/decrement should work in px unit', async () => {
+      const editor = hook.editor();
+      editor.setContent('<p style="font-size: 16px;">abc</p>');
+      TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 3);
+      await pWaitForInputValue(editor, '16px');
+
+      TinyUiActions.clickOnToolbar(editor, '.tox-number-input .plus');
+      await pWaitForInputValue(editor, '17px');
+
+      TinyUiActions.clickOnToolbar(editor, '.tox-number-input .minus');
+      await pWaitForInputValue(editor, '16px');
+    });
+  });
+
+  context('Configured unit: em', () => {
+    const hook = TinyHooks.bddSetupLight<Editor>({
+      base_url: '/project/tinymce/js/tinymce',
+      toolbar: [ 'fontsizeinput' ],
+      font_size_input_default_unit: 'em'
+    }, []);
+
+    it('TINY-UNIT-6: should display font size in em when unit is configured as em', async () => {
+      const editor = hook.editor();
+      // em is relative, so we can't convert px to em without knowing the parent font size
+      // The conversion should fall back to displaying the raw value when em is the target
+      editor.setContent('<p style="font-size: 2em;">abc</p>');
+      TinySelections.setCursor(editor, [ 0, 0 ], 1);
+      // Browser computes em to px, so queryCommandValue returns px
+      // We can't convert back to em without context, so it should display px
+      // This test documents the expected behavior
+      await Waiter.pWait(100);
+      const value = getInputValue(editor);
+      // Should show some value (px since em conversion from px isn't supported)
+      assert.isNotEmpty(value, 'Input should have a value');
+    });
+  });
+
+  context('Dropdown and input consistency', () => {
+    const hook = TinyHooks.bddSetupLight<Editor>({
+      base_url: '/project/tinymce/js/tinymce',
+      toolbar: [ 'fontsize fontsizeinput' ]
+    }, []);
+
+    it('TINY-UNIT-7: fontsize dropdown and fontsizeinput should show consistent values', async () => {
+      const editor = hook.editor();
+      editor.setContent('<p style="font-size: 16px;">abc</p>');
+      TinySelections.setCursor(editor, [ 0, 0 ], 1);
+
+      // The input should show 12pt (converted from 16px)
+      await pWaitForInputValue(editor, '12pt');
+
+      // The dropdown should also show 12pt
+      const dropdownValue = UiFinder.findIn(TinyUiActions.getUiRoot(editor), '.tox-tbtn--select .tox-tbtn__select-label').getOrDie();
+      await Waiter.pTryUntil('Dropdown should show 12pt', () => {
+        const text = dropdownValue.dom.textContent ?? '';
+        assert.equal(text, '12pt');
+      });
+    });
+  });
+
+  context('Backwards compatibility', () => {
+    const hook = TinyHooks.bddSetupLight<Editor>({
+      base_url: '/project/tinymce/js/tinymce',
+      toolbar: [ 'fontsizeinput' ]
+    }, []);
+
+    it('TINY-UNIT-8: typing a bare number should still apply the default unit', async () => {
+      const editor = hook.editor();
+      const root = SugarShadowDom.getRootNode(TinyDom.targetElement(editor));
+      editor.setContent('<p style="font-size: 16px;">abc</p>');
+      TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 3);
+
+      const input = TinyUiActions.clickOnToolbar<HTMLInputElement>(editor, '.tox-number-input input');
+      UiControls.setValue(input, '20');
+      FocusTools.setFocus(root, '.tox-number-input input');
+      await FocusTools.pTryOnSelector('Focus should be on input', root, '.tox-number-input input');
+      TinyUiActions.keystroke(editor, Keys.enter());
+
+      // With default unit pt, typing "20" should apply "20pt"
+      TinyAssertions.assertContentPresence(editor, { 'span[style*="20pt"]': 1 });
+    });
+  });
+});


### PR DESCRIPTION
Closes #6

## Summary
- `fontsizeinput` now converts the raw browser-computed px value to the configured `font_size_input_default_unit` before displaying
- The dropdown (`fontsize`) and input (`fontsizeinput`) now show consistent values (e.g. both show `12pt` instead of dropdown showing `12pt` and input showing `16px`)
- Increment/decrement buttons work correctly in the configured unit

## Changes
- **`FontSizeBespoke.ts`** — Generalized `toPt()` into a reusable `convertFromPx()` function. Added `convertToUnit()` for display value conversion. Updated `getNumberInputSpec()` to convert display values via `getDisplayValue()`.
- **`FontSizeInputUnitConversionTest.ts`** (new) — 8 test cases covering default pt display, px mode, em fallback, dropdown/input consistency, increment/decrement in pt, and backwards compatibility for bare number input.

## Edge Cases Investigated
- [x] Default (pt) — `16px` displays as `12pt` ✅
- [x] px mode — `16px` displays as `16px` (no conversion) ✅
- [x] em mode — browser computes em to px, can't convert back without parent context → falls back to raw px value ⚠️ (documented, unlikely config)
- [x] Increment/decrement — works correctly in display unit ✅
- [x] Bare number input — still applies default unit (existing behavior preserved) ✅
- [x] Dropdown and input consistency — both show same value ✅
- [x] Keyword font sizes (small, medium, large) — converted via lookup table ✅

## Browser Verification
Verified in dev server at `localhost:3000` with `fontsize` and `fontsizeinput` side by side on the toolbar. Both show `12pt` for default content, both update to `13pt` after clicking +.

## Manual Testing
To test different configurations, edit `modules/tinymce/src/themes/silver/demo/ts/demo/PlayDemo.ts`:
- Add `fontsize` and `fontsizeinput` to the toolbar string
- Add `font_size_input_default_unit: 'px'` (or `'pt'`, `'cm'`, etc.) to the init config
- Run `yarn tinymce-dev` and navigate to `http://localhost:3000/src/themes/silver/demo/html/demo/demo.html`

## Proposed Documentation Update

**Page:** https://www.tiny.cloud/docs/tinymce/latest/user-formatting-options/#font_size_input_default_unit

Add a note clarifying that `font_size_input_default_unit` now controls the display unit of the `fontsizeinput` toolbar component, not just the unit applied when entering a bare number. The input will convert the browser's computed px value to the configured unit for display.

🤖 Generated with [Claude Code](https://claude.com/claude-code)