### PR TITLE
Support fixed_toolbar_container in iframe mode

### DIFF
--- a/modules/tinymce/src/core/demo/html/fixed_toolbar_container_demo.html
+++ b/modules/tinymce/src/core/demo/html/fixed_toolbar_container_demo.html
@@ -8,10 +8,20 @@
 <body>
   <main>
     <h1>fixed_toolbar_container Demo Page</h1>
-    <br />
-    <div id="toolbar"></div>
-    <br/>
-    <div id="editor">fixed_toolbar_container demo</div>
+
+    <h2>Inline mode (existing)</h2>
+    <div id="toolbar-inline" style="border: 1px solid #ccc; padding: 4px; margin-bottom: 8px;"></div>
+    <div id="editor-inline">fixed_toolbar_container inline demo</div>
+
+    <hr style="margin: 32px 0;" />
+
+    <h2>Iframe mode (new)</h2>
+    <p>The toolbar is rendered in the container below. Other content lives between the toolbar and the editor.</p>
+    <div id="toolbar-iframe" style="border: 1px solid #ccc; padding: 4px; margin-bottom: 8px;"></div>
+    <p style="background: #f0f4ff; padding: 12px; border-radius: 4px;">
+      📌 This content lives between the toolbar and the editor — demonstrating layout freedom.
+    </p>
+    <textarea id="editor-iframe">fixed_toolbar_container iframe demo</textarea>
     <br/>
     <script src="../../../../js/tinymce/tinymce.js"></script>
     <script src="../../../../scratch/demos/core/demo.js"></script>

--- a/modules/tinymce/src/core/demo/ts/demo/FixedToolbarContainerDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/FixedToolbarContainerDemo.ts
@@ -3,10 +3,22 @@ import type { TinyMCE } from 'tinymce/core/api/PublicApi';
 declare let tinymce: TinyMCE;
 
 export default (): void => {
+  // Existing: inline mode with fixed_toolbar_container
   tinymce.init({
-    selector: '#editor',
+    selector: '#editor-inline',
     license_key: 'gpl',
     inline: true,
-    fixed_toolbar_container: '#toolbar',
+    fixed_toolbar_container: '#toolbar-inline',
+  });
+
+  // New: iframe mode with fixed_toolbar_container
+  // The toolbar renders in #toolbar-iframe while the editor iframe stays at #editor-iframe.
+  // This demonstrates layout freedom — other content can live between the toolbar and editor.
+  tinymce.init({
+    selector: '#editor-iframe',
+    license_key: 'gpl',
+    plugins: 'lists link image table wordcount',
+    toolbar: 'bold italic underline | bullist numlist | link image table',
+    fixed_toolbar_container: '#toolbar-iframe',
   });
 };

--- a/modules/tinymce/src/core/demo/ts/demo/FixedToolbarContainerDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/FixedToolbarContainerDemo.ts
@@ -18,7 +18,8 @@ export default (): void => {
     selector: '#editor-iframe',
     license_key: 'gpl',
     plugins: 'lists link image table wordcount',
-    toolbar: 'bold italic underline | bullist numlist | link image table',
+    toolbar: 'undo redo styles fontsize fontfamily bold italic underline forecolor backcolor | bullist numlist | link image table | wordcount code help',
     fixed_toolbar_container: '#toolbar-iframe',
+    toolbar_mode: "floating"
   });
 };

--- a/modules/tinymce/src/themes/silver/main/ts/Render.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/Render.ts
@@ -17,7 +17,7 @@ import * as Deprecations from './Deprecations';
 import * as DomEvents from './Events';
 import * as Iframe from './modes/Iframe';
 import * as Inline from './modes/Inline';
-import { LazyUiReferences, type ReadyUiReferences, type SinkAndMothership } from './modes/UiReferences';
+import { type HeaderUi, LazyUiReferences, type ReadyUiReferences, type SinkAndMothership } from './modes/UiReferences';
 import * as ContextToolbar from './ui/context/ContextToolbar';
 import * as FormatControls from './ui/core/FormatControls';
 import OuterContainer from './ui/general/OuterContainer';
@@ -110,8 +110,11 @@ const setup = (editor: Editor, setupForTheme: ThemeRenderSetup): RenderInfo => {
   });
 
   const lazyHeader = () => lazyUiRefs.mainUi.get()
-    .map((ui) => ui.outerContainer)
-    .bind(OuterContainer.getHeader);
+    .bind((ui) =>
+      // When fixed_toolbar_container is used in iframe mode, the header lives in headerUi
+      ui.headerUi.bind((h) => OuterContainer.getHeader(h.outerContainer))
+        .orThunk(() => OuterContainer.getHeader(ui.outerContainer))
+    );
 
   const lazyDialogSinkResult = () => Result.fromOption(
     lazyUiRefs.dialogUi.get().map((ui) => ui.sink),
@@ -380,12 +383,18 @@ const setup = (editor: Editor, setupForTheme: ThemeRenderSetup): RenderInfo => {
         renderStatusbar(editor, backstages.popup.shared.providers)
       ) : Optional.none<AlloySpec>();
 
+    // When fixed_toolbar_container is set in iframe mode, the header (menubar + toolbar)
+    // is rendered in a separate outerContainer attached to the fixed container element.
+    // The main outerContainer holds only the socket, sidebar, and statusbar.
+    const useFixedContainerInIframeMode = Options.useFixedContainer(editor) && !isInline;
+
     // We need the statusbar to be separate to everything else so resizing works properly
     const editorComponents = Arr.flatten<AlloySpec>([
-      isToolbarBottom ? [ ] : [ partHeader ],
+      // Exclude header from main outerContainer if it goes in the fixed container
+      isToolbarBottom || useFixedContainerInIframeMode ? [ ] : [ partHeader ],
       // Inline mode does not have a socket/sidebar
       isInline ? [ ] : [ sidebarContainer ],
-      isToolbarBottom ? [ partHeader ] : [ ]
+      isToolbarBottom && !useFixedContainerInIframeMode ? [ partHeader ] : [ ]
     ]);
 
     const editorContainer = OuterContainer.parts.editorContainer({
@@ -443,7 +452,37 @@ const setup = (editor: Editor, setupForTheme: ThemeRenderSetup): RenderInfo => {
 
     lazyMothership.set(mothership);
 
-    return { mothership, outerContainer };
+    // Build a separate header outerContainer for fixed container iframe mode
+    const headerUi: Optional<HeaderUi> = useFixedContainerInIframeMode ? (() => {
+      const headerOuterContainer = GuiFactory.build(
+        OuterContainer.sketch({
+          dom: {
+            tag: 'div',
+            classes: [ 'tox', 'tox-tinymce', 'tox-tinymce--toolbar-only' ].concat(deviceClasses),
+            styles: { visibility: 'hidden' }
+          },
+          components: [
+            OuterContainer.parts.editorContainer({
+              components: [ partHeader ]
+            })
+          ],
+          behaviours: Behaviour.derive([
+            UiState.toggleOnReceive(() => backstages.popup.shared.providers.checkUiComponentContext('any')),
+            Disabling.config({
+              disableClass: 'tox-tinymce--disabled'
+            }),
+            Keying.config({
+              mode: 'cyclic',
+              selector: '.tox-menubar, .tox-toolbar, .tox-toolbar__primary, .tox-toolbar__overflow--open'
+            })
+          ])
+        })
+      );
+      const headerMothership = Gui.takeover(headerOuterContainer);
+      return Optional.some({ mothership: headerMothership, outerContainer: headerOuterContainer });
+    })() : Optional.none();
+
+    return { mothership, outerContainer, headerUi };
   };
 
   const setEditorSize = (outerContainer: AlloyComponent) => {
@@ -517,7 +556,9 @@ const setup = (editor: Editor, setupForTheme: ThemeRenderSetup): RenderInfo => {
       views
     };
 
-    setupShortcutsAndCommands(mainUi.outerContainer);
+    // When fixed_toolbar_container is used in iframe mode, toolbar/menubar shortcuts
+    // must target the headerUi.outerContainer where those components live
+    setupShortcutsAndCommands(mainUi.headerUi.map((h) => h.outerContainer).getOr(mainUi.outerContainer));
     DomEvents.setup(editor, mainUi.mothership, uiMotherships);
 
     // This backstage needs to kept in sync with the one passed to the Header part.

--- a/modules/tinymce/src/themes/silver/main/ts/api/Options.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/api/Options.ts
@@ -396,11 +396,6 @@ const isToolbarLocationBottom = (editor: Editor): boolean =>
   getToolbarLocation(editor) === ToolbarLocation.bottom;
 
 const fixedContainerTarget = (editor: Editor): Optional<SugarElement> => {
-  if (!editor.inline) {
-    // fixed_toolbar_container(_target) is only available in inline mode
-    return Optional.none();
-  }
-
   const selector = fixedContainerSelector(editor) ?? '';
   if (selector.length > 0) {
     // If we have a valid selector
@@ -417,7 +412,7 @@ const fixedContainerTarget = (editor: Editor): Optional<SugarElement> => {
 };
 
 const useFixedContainer = (editor: Editor): boolean =>
-  editor.inline && fixedContainerTarget(editor).isSome();
+  fixedContainerTarget(editor).isSome();
 
 const getUiContainer = (editor: Editor): SugarElement<HTMLElement | ShadowRoot> => {
   const fixedContainer = fixedContainerTarget(editor);
@@ -471,6 +466,7 @@ export {
   isToolbarPersist,
   getMultipleToolbarsOption,
   getUiContainer,
+  fixedContainerTarget,
   useFixedContainer,
   isSplitUiMode,
   getToolbarMode,

--- a/modules/tinymce/src/themes/silver/main/ts/modes/Iframe.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/modes/Iframe.ts
@@ -191,7 +191,7 @@ const render = (editor: Editor, uiRefs: ReadyUiReferences, rawUiConfig: RenderUi
       if (Type.isNull(OuterContainer.whichView(outerContainer))) {
         editor.focus();
         editor.nodeChanged();
-        OuterContainer.refreshToolbar(outerContainer);
+        OuterContainer.refreshToolbar(toolbarContainer);
       }
 
       Events.fireToggleView(editor);
@@ -201,14 +201,23 @@ const render = (editor: Editor, uiRefs: ReadyUiReferences, rawUiConfig: RenderUi
 
   const toolbarMode = Options.getToolbarMode(editor);
 
+  // When fixed_toolbar_container is used, the toolbar lives in headerUi — refresh that.
+  // Also measure the toolbar container's width (not the iframe width) since the toolbar
+  // reflows based on its own container width, which may differ from the editor iframe width.
+  const toolbarContainer = mainUi.headerUi.map((h) => h.outerContainer).getOr(outerContainer);
+  const getToolbarWidth = () => mainUi.headerUi.fold(
+    () => editor.getWin().innerWidth,
+    (h) => h.outerContainer.element.dom.offsetWidth
+  );
+
   const refreshDrawer = () => {
-    OuterContainer.refreshToolbar(uiRefs.mainUi.outerContainer);
+    OuterContainer.refreshToolbar(toolbarContainer);
   };
 
   if (toolbarMode === Options.ToolbarMode.sliding || toolbarMode === Options.ToolbarMode.floating) {
     editor.on('ResizeWindow ResizeEditor ResizeContent', () => {
       // Check if the width has changed, if so then refresh the toolbar drawer. We don't care if height changes.
-      const width = editor.getWin().innerWidth;
+      const width = getToolbarWidth();
       if (width !== lastToolbarWidth.get()) {
         refreshDrawer();
         lastToolbarWidth.set(width);

--- a/modules/tinymce/src/themes/silver/main/ts/modes/Iframe.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/modes/Iframe.ts
@@ -107,6 +107,20 @@ const render = (editor: Editor, uiRefs: ReadyUiReferences, rawUiConfig: RenderUi
   const uiRoot = SugarShadowDom.getContentContainer(SugarShadowDom.getRootNode(eTargetNode));
 
   Attachment.attachSystemAfter(eTargetNode, mainUi.mothership);
+
+  // When fixed_toolbar_container is used in iframe mode, attach the header (toolbar + menubar)
+  // mothership to the fixed container element so it renders there instead of above the iframe.
+  mainUi.headerUi.each((headerUi) => {
+    Options.fixedContainerTarget(editor).each((fixedContainer) => {
+      Attachment.attachSystem(fixedContainer, headerUi.mothership);
+    });
+    // Detach the header mothership when the editor is destroyed, since it's not inside
+    // editor.getContainer() and won't be cleaned up by the normal DOM.remove() path.
+    editor.on('remove', () => {
+      Attachment.detachSystem(headerUi.mothership);
+    });
+  });
+
   attachUiMotherships(editor, uiRoot, uiRefs);
 
   editor.on('PostRender', () => {
@@ -133,7 +147,7 @@ const render = (editor: Editor, uiRefs: ReadyUiReferences, rawUiConfig: RenderUi
     lastToolbarWidth.set(editor.getWin().innerWidth);
 
     OuterContainer.setMenubar(
-      outerContainer,
+      mainUi.headerUi.map((h) => h.outerContainer).getOr(outerContainer),
       identifyMenus(editor, rawUiConfig)
     );
 

--- a/modules/tinymce/src/themes/silver/main/ts/modes/Toolbars.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/modes/Toolbars.ts
@@ -11,7 +11,8 @@ import type { ReadyUiReferences } from './UiReferences';
 
 // Set toolbar(s) depending on if multiple toolbars is configured or not
 const setToolbar = (editor: Editor, uiRefs: ReadyUiReferences, rawUiConfig: RenderUiConfig, backstage: UiFactoryBackstage): void => {
-  const outerContainer = uiRefs.mainUi.outerContainer;
+  // When fixed_toolbar_container is used in iframe mode, the toolbar lives in headerUi
+  const outerContainer = uiRefs.mainUi.headerUi.map((h) => h.outerContainer).getOr(uiRefs.mainUi.outerContainer);
   const toolbarConfig = rawUiConfig.toolbar;
   const toolbarButtonsConfig = rawUiConfig.buttons;
 

--- a/modules/tinymce/src/themes/silver/main/ts/modes/UiReferences.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/modes/UiReferences.ts
@@ -1,5 +1,5 @@
 import type { AlloyComponent, Gui } from '@ephox/alloy';
-import { type Optional, Singleton } from '@ephox/katamari';
+import { Optional, Singleton } from '@ephox/katamari';
 import { Compare } from '@ephox/sugar';
 
 export interface SinkAndMothership {
@@ -7,9 +7,17 @@ export interface SinkAndMothership {
   readonly mothership: Gui.GuiSystem;
 }
 
+export interface HeaderUi {
+  readonly mothership: Gui.GuiSystem;
+  readonly outerContainer: AlloyComponent;
+}
+
 export interface MainUi {
   readonly mothership: Gui.GuiSystem;
   readonly outerContainer: AlloyComponent;
+  // When fixed_toolbar_container is used in iframe mode, the header (toolbar + menubar)
+  // is rendered in a separate mothership attached to the fixed container.
+  readonly headerUi: Optional<HeaderUi>;
 }
 
 export interface ReadyUiReferences {
@@ -37,11 +45,12 @@ export interface LazyUiReferences {
 export const LazyUiReferences = (): LazyUiReferences => {
   const dialogUi = Singleton.value<SinkAndMothership>();
   const popupUi = Singleton.value<SinkAndMothership>();
-  const mainUi = Singleton.value<{ mothership: Gui.GuiSystem; outerContainer: AlloyComponent }>();
+  const mainUi = Singleton.value<MainUi>();
 
   const lazyGetInOuterOrDie = <A>(label: string, f: (oc: AlloyComponent) => Optional<A>): () => A =>
     () => mainUi.get().bind(
-      (oc) => f(oc.outerContainer)
+      // Check headerUi first (toolbar/menubar live there when fixed_toolbar_container is used in iframe mode)
+      (ui) => ui.headerUi.bind((h) => f(h.outerContainer)).orThunk(() => f(ui.outerContainer))
     ).getOrDie(
       `Could not find ${label} element in OuterContainer`
     );
@@ -50,13 +59,20 @@ export const LazyUiReferences = (): LazyUiReferences => {
   const getUiMotherships = () => {
     const optDialogMothership = dialogUi.get().map((ui) => ui.mothership);
     const optPopupMothership = popupUi.get().map((ui) => ui.mothership);
+    // Include the header mothership when fixed_toolbar_container is used in iframe mode
+    const optHeaderMothership = mainUi.get().bind((ui) => ui.headerUi).map((h) => h.mothership);
 
-    return optDialogMothership.fold(
+    const base = optDialogMothership.fold(
       () => optPopupMothership.toArray(),
       (dm) => optPopupMothership.fold(
         () => [ dm ],
         (pm) => Compare.eq(dm.element, pm.element) ? [ dm ] : [ dm, pm ]
       )
+    );
+
+    return optHeaderMothership.fold(
+      () => base,
+      (hm) => [ hm, ...base ]
     );
   };
 

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverFixedToolbarContainerIframeTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverFixedToolbarContainerIframeTest.ts
@@ -1,0 +1,96 @@
+import { UiFinder, Waiter } from '@ephox/agar';
+import { after, before, describe, it } from '@ephox/bedrock-client';
+import { Arr } from '@ephox/katamari';
+import { Insert, Remove, SugarBody, SugarElement } from '@ephox/sugar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
+import { assert } from 'chai';
+
+import type Editor from 'tinymce/core/api/Editor';
+
+describe('browser.tinymce.themes.silver.editor.SilverFixedToolbarContainerIframeTest', () => {
+  let toolbar: SugarElement<HTMLDivElement>;
+
+  before(() => {
+    toolbar = SugarElement.fromHtml('<div id="fixed-toolbar-test" style="margin: 50px 0;"></div>');
+    Insert.append(SugarBody.body(), toolbar);
+  });
+
+  after(() => {
+    Remove.remove(toolbar);
+  });
+
+  const hook = TinyHooks.bddSetup<Editor>({
+    inline: false,
+    fixed_toolbar_container: '#fixed-toolbar-test',
+    menubar: 'file',
+    toolbar: 'undo bold',
+    base_url: '/project/tinymce/js/tinymce'
+  }, []);
+
+  it('Toolbar is rendered in the fixed container', async () => {
+    const editor = hook.editor();
+    editor.setContent('<p>test content</p>');
+    editor.focus();
+
+    await Waiter.pTryUntil('Wait for toolbar header', () =>
+      UiFinder.findIn(toolbar, '.tox-editor-header').getOrDie()
+    );
+  });
+
+  it('Editor socket (iframe) is rendered in main editor container, not the fixed container', async () => {
+    const editor = hook.editor();
+    editor.setContent('<p>test content</p>');
+    editor.focus();
+
+    await Waiter.pTryUntil('Wait for edit area', () =>
+      UiFinder.findIn(SugarElement.fromDom(editor.editorContainer), '.tox-edit-area').getOrDie()
+    );
+
+    // The iframe should NOT be in the fixed container
+    assert.equal(UiFinder.findAllIn(toolbar, '.tox-edit-area').length, 0,
+      'Fixed container should not contain .tox-edit-area');
+  });
+
+  it('Toolbar contains the configured toolbar buttons', async () => {
+    const editor = hook.editor();
+    editor.setContent('<p>test content</p>');
+    editor.focus();
+
+    await Waiter.pTryUntil('Wait for Undo button in fixed container', () =>
+      UiFinder.findIn(toolbar, '[aria-label="Undo"]').getOrDie()
+    );
+
+    UiFinder.findIn(toolbar, '[aria-label="Bold"]').getOrDie();
+  });
+
+  it('Menu bar is rendered in the fixed container', async () => {
+    const editor = hook.editor();
+    editor.setContent('<p>test content</p>');
+    editor.focus();
+
+    await Waiter.pTryUntil('Wait for menubar in fixed container', () =>
+      UiFinder.findIn(toolbar, '.tox-menubar').getOrDie()
+    );
+
+    // The menubar should NOT be in the main editor container
+    const editorContainer = SugarElement.fromDom(editor.editorContainer);
+    assert.equal(
+      Arr.filter(UiFinder.findAllIn(editorContainer, '.tox-menubar'), (el) => !toolbar.dom.contains(el.dom)).length,
+      0,
+      'Main editor container should not contain its own .tox-menubar'
+    );
+  });
+
+  it('Status bar remains in the main editor container', async () => {
+    const editor = hook.editor();
+    editor.setContent('<p>test content</p>');
+    editor.focus();
+
+    await Waiter.pTryUntil('Wait for statusbar', () =>
+      UiFinder.findIn(SugarElement.fromDom(editor.editorContainer), '.tox-statusbar').getOrDie()
+    );
+
+    assert.equal(UiFinder.findAllIn(toolbar, '.tox-statusbar').length, 0,
+      'Fixed container should not contain .tox-statusbar');
+  });
+});

--- a/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverFixedToolbarContainerTargetNotInlineTest.ts
+++ b/modules/tinymce/src/themes/silver/test/ts/browser/editor/SilverFixedToolbarContainerTargetNotInlineTest.ts
@@ -1,7 +1,7 @@
-﻿import { Assertions } from '@ephox/agar';
+﻿import { UiFinder, Waiter } from '@ephox/agar';
 import { after, before, describe, it } from '@ephox/bedrock-client';
 import { Insert, Remove, SugarBody, SugarElement } from '@ephox/sugar';
-import { TinyHooks, TinyUiActions } from '@ephox/wrap-mcagar';
+import { TinyHooks } from '@ephox/wrap-mcagar';
 
 import type Editor from 'tinymce/core/api/Editor';
 
@@ -23,12 +23,13 @@ describe('browser.tinymce.themes.silver.editor.SilverFixedToolbarContainerTarget
     base_url: '/project/tinymce/js/tinymce'
   }, []);
 
-  it('Check fixed_toolbar_container_target setting is ignored when not an inline editor', async () => {
+  it('Check fixed_toolbar_container_target renders toolbar in the target container in iframe mode', async () => {
     const editor = hook.editor();
     editor.setContent('fixed_toolbar_container_target test');
     editor.focus();
 
-    await TinyUiActions.pWaitForUi(editor, '.tox-editor-header');
-    Assertions.assertHtml('Check that the inline toolbar is still empty', '', toolbar.dom.innerHTML);
+    await Waiter.pTryUntil('Wait for toolbar header in target container', () =>
+      UiFinder.findIn(toolbar, '.tox-editor-header').getOrDie()
+    );
   });
 });


### PR DESCRIPTION
Closes #20

## Summary
- `fixed_toolbar_container` and `fixed_toolbar_container_target` now work in iframe mode (previously only inline mode)
- Toolbar + menubar are rendered in a separate Alloy mothership attached to the fixed container
- Socket (iframe), sidebar, statusbar remain in their normal position — layout freedom achieved
- Toolbar is always visible (no show/hide on focus, matching inline mode behavior)
- Proper cleanup: header mothership is detached when editor is removed

## Changes
- **`Options.ts`** — removed `editor.inline` gate from `fixedContainerTarget()` and `useFixedContainer()`
- **`UiReferences.ts`** — added `HeaderUi` interface and `headerUi: Optional<HeaderUi>` to `MainUi`
- **`Render.ts`** — when `useFixedContainer && !inline`: builds separate `headerOuterContainer` with only the header; main `outerContainer` built without header; `lazyHeader` and `setupShortcutsAndCommands` updated to check `headerUi` first
- **`Iframe.ts`** — attaches `headerUi.mothership` to fixed container; adds `remove` listener to detach header on editor destroy
- **`Toolbars.ts`** — `setToolbar` uses `headerUi.outerContainer` when available

## Architecture: Two Motherships
When `fixed_toolbar_container` is set in iframe mode, two separate Alloy motherships are created:
1. `headerMothership` → attached to the fixed container element (menubar + toolbar)
2. `mainMothership` → attached after the target textarea (socket + statusbar)

This is the same pattern used by `ui_mode: split` and avoids DOM reparenting after render.

## Test plan
- [x] Toolbar and menubar rendered inside fixed container in iframe mode
- [x] Editor iframe and statusbar remain in main editor container
- [x] Configured toolbar buttons appear in fixed container
- [x] Status bar remains in main editor container
- [x] Existing inline mode with `fixed_toolbar_container` still works
- [x] Build and TypeScript compile clean
- [x] Browser verified: toolbar above content separator above editor ✓

## Demo
Open `http://localhost:3000/src/core/demo/html/fixed_toolbar_container_demo.html` — bottom section shows iframe mode with content between toolbar and editor.

**Manual testing needed:**
- Toolbar buttons function correctly (bold, link, table dialogs open)
- Alt+F9 (focus menubar) and Alt+F10 (focus toolbar) keyboard shortcuts work
- `editor.remove()` cleans up header from fixed container
- Multiple editors with separate fixed containers work independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)